### PR TITLE
fix DSCR report key reference

### DIFF
--- a/src/components/outputs/DSCRReport.tsx
+++ b/src/components/outputs/DSCRReport.tsx
@@ -169,7 +169,7 @@ export default function DSCRReport({ formData, data }: Props) {
             </td>
             {totalRepayments.map((amt, i) => (
               <td
-                key={`rep-${data[i].year}`}
+                key={`rep-${schedule[i]?.year ?? i}`}
                 className="border border-gray-300 p-2 text-right"
               >
                 {fmtAmt(amt)}


### PR DESCRIPTION
## Summary
- avoid crash in DSCR report when repayment schedule extends beyond projection data by guarding against missing year values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: SalesRevenue.tsx: error TS6133: 'React' is declared but its value is never read.*


------
https://chatgpt.com/codex/tasks/task_e_6894e04af72483339e6ce690196551e8