### PR TITLE
Revamp financial assumptions and calculations

### DIFF
--- a/src/components/form-sections/Depreciation.tsx
+++ b/src/components/form-sections/Depreciation.tsx
@@ -43,6 +43,29 @@ export default function Depreciation({ control }: { control: Control<FormValues>
             </FormItem>
           )}
         />
+
+        <FormField
+          control={control}
+          name="depreciationRate"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Depreciation Rate %</FormLabel>
+              <FormControl>
+                <Select onValueChange={field.onChange} defaultValue={String(field.value)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select rate" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[10,15,40].map((r) => (
+                      <SelectItem key={r} value={String(r)}>{r}%</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
       </div>
     </section>
   );

--- a/src/components/form-sections/ExpenseAssumptions.tsx
+++ b/src/components/form-sections/ExpenseAssumptions.tsx
@@ -59,10 +59,22 @@ export default function ExpenseAssumptions({ control }: { control: Control<FormV
 
         <FormField
           control={control}
-          name="sellingExpensesMonthly"
+          name="outwardFreightMonthly"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Selling Expenses (Monthly)</FormLabel>
+              <FormLabel>Outward Freight (Monthly)</FormLabel>
+              <FormControl><Input type="number" {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={control}
+          name="inwardFreightMonthly"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Inward Freight (Monthly)</FormLabel>
               <FormControl><Input type="number" {...field} /></FormControl>
               <FormMessage />
             </FormItem>

--- a/src/components/form-sections/FundingLoans.tsx
+++ b/src/components/form-sections/FundingLoans.tsx
@@ -7,7 +7,9 @@ import {
   FormControl,
   FormMessage,
 } from "@/components/ui/form";
+import { useFormContext, useWatch } from "react-hook-form";
 import type { Control } from "react-hook-form";
+import type { CostItem } from "@/types/formTypes";
 import type { FormValues } from "@/types/formTypes";
 
 export default function FundingLoans({
@@ -15,6 +17,25 @@ export default function FundingLoans({
 }: {
   control: Control<FormValues>;
 }) {
+  const { setValue } = useFormContext<FormValues>();
+  const costItems = useWatch({ control, name: "costItems" }) as CostItem[];
+  const capPct = useWatch({ control, name: "capitalSubsidyPercent" });
+
+  const totalCost =
+    costItems?.reduce((sum: number, item: CostItem) => sum + Number(item.amount || 0), 0) || 0;
+  const totalMargin =
+    costItems?.reduce(
+      (sum: number, item: CostItem) =>
+        sum + Number(item.amount || 0) * (Number(item.marginPercent || 0) / 100),
+      0
+    ) || 0;
+  const wcRequirement =
+    costItems?.find((i: CostItem) => i.type === "Working Capital Requirement")?.amount || 0;
+
+  setValue("ownerCapital", totalMargin);
+  setValue("termLoanAmount", totalCost - totalMargin);
+  setValue("wcLoanAmount", wcRequirement);
+  setValue("capitalSubsidyAmount", (totalCost * Number(capPct || 0)) / 100);
   return (
     <section className="border border-slate-200 rounded-md p-6 shadow-sm">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">4️⃣ Funding / Loans</h2>
@@ -25,7 +46,7 @@ export default function FundingLoans({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Owner Capital</FormLabel>
-              <FormControl><Input type="number" {...field} /></FormControl>
+              <FormControl><Input type="number" readOnly {...field} /></FormControl>
               <FormMessage />
             </FormItem>
           )}
@@ -37,7 +58,7 @@ export default function FundingLoans({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Term Loan Amount</FormLabel>
-              <FormControl><Input type="number" {...field} /></FormControl>
+              <FormControl><Input type="number" readOnly {...field} /></FormControl>
               <FormMessage />
             </FormItem>
           )}
@@ -85,7 +106,7 @@ export default function FundingLoans({
           render={({ field }) => (
             <FormItem>
               <FormLabel>Working Capital Loan</FormLabel>
-              <FormControl><Input type="number" {...field} /></FormControl>
+              <FormControl><Input type="number" readOnly {...field} /></FormControl>
               <FormMessage />
             </FormItem>
           )}
@@ -98,18 +119,6 @@ export default function FundingLoans({
             <FormItem>
               <FormLabel>Working Capital Interest %</FormLabel>
               <FormControl><Input type="number" step="0.01" {...field} /></FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={control}
-          name="wcLoanTenure"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Working Capital Tenure (Months)</FormLabel>
-              <FormControl><Input type="number" {...field} /></FormControl>
               <FormMessage />
             </FormItem>
           )}
@@ -134,6 +143,18 @@ export default function FundingLoans({
             <FormItem>
               <FormLabel>Capital Subsidy %</FormLabel>
               <FormControl><Input type="number" step="0.01" {...field} /></FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={control}
+          name="capitalSubsidyAmount"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Capital Subsidy Amount</FormLabel>
+              <FormControl><Input type="number" readOnly {...field} /></FormControl>
               <FormMessage />
             </FormItem>
           )}

--- a/src/components/form-sections/LedgerCashflow.tsx
+++ b/src/components/form-sections/LedgerCashflow.tsx
@@ -2,6 +2,7 @@
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { Control } from "react-hook-form";
 import type { FormValues } from "@/types/formTypes";
 
@@ -72,23 +73,22 @@ export default function LedgerCashflow({ control }: { control: Control<FormValue
 
         <FormField
           control={control}
-          name="taxRate"
+          name="taxPercentage"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Tax Rate %</FormLabel>
-              <FormControl><Input type="number" step="0.01" {...field} /></FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={control}
-          name="gstRate"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>GST Rate %</FormLabel>
-              <FormControl><Input type="number" step="0.01" {...field} /></FormControl>
+              <FormLabel>Tax Percentage</FormLabel>
+              <FormControl>
+                <Select onValueChange={field.onChange} defaultValue={String(field.value)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[0,5,12,18,28].map((rate) => (
+                      <SelectItem key={rate} value={String(rate)}>{rate}%</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
               <FormMessage />
             </FormItem>
           )}

--- a/src/components/form-sections/SalesRevenue.tsx
+++ b/src/components/form-sections/SalesRevenue.tsx
@@ -1,4 +1,3 @@
-// src/components/form-sections/SalesRevenue.tsx
 import { Input } from "@/components/ui/input";
 import {
   FormField,
@@ -7,7 +6,9 @@ import {
   FormControl,
   FormMessage,
 } from "@/components/ui/form";
+import { Button } from "@/components/ui/button";
 import type { Control } from "react-hook-form";
+import { useFieldArray } from "react-hook-form";
 import type { FormValues } from "@/types/formTypes";
 
 export default function SalesRevenue({
@@ -15,26 +16,103 @@ export default function SalesRevenue({
 }: {
   control: Control<FormValues>;
 }) {
+  const { fields, append, remove } = useFieldArray({ control, name: "products" });
   return (
     <section className="border border-slate-200 rounded-md p-6 shadow-sm">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">
         5️⃣ Sales & Revenue Assumptions
       </h2>
+      <table className="w-full text-sm border-collapse mb-4">
+        <thead>
+          <tr className="bg-slate-100">
+            <th className="p-2 text-left border">Product</th>
+            <th className="p-2 text-right border">Unit Price</th>
+            <th className="p-2 text-right border">Quantity</th>
+            <th className="p-2 text-left border">Unit</th>
+            <th className="p-2 border"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {fields.map((field, index) => (
+            <tr key={field.id}>
+              <td className="p-2 border">
+                <FormField
+                  control={control}
+                  name={`products.${index}.name`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </td>
+              <td className="p-2 border">
+                <FormField
+                  control={control}
+                  name={`products.${index}.unitPrice`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input type="number" className="text-right" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </td>
+              <td className="p-2 border">
+                <FormField
+                  control={control}
+                  name={`products.${index}.quantity`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input type="number" className="text-right" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </td>
+              <td className="p-2 border">
+                <FormField
+                  control={control}
+                  name={`products.${index}.unit`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </td>
+              <td className="p-2 border text-center">
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => remove(index)}
+                >
+                  Remove
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Button
+        type="button"
+        onClick={() => append({ name: "", unitPrice: 0, quantity: 0, unit: "" })}
+        className="mb-4"
+      >
+        Add Product
+      </Button>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <FormField
-          control={control}
-          name="baseYearSales"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Base Year Sales</FormLabel>
-              <FormControl>
-                <Input type="number" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
         <FormField
           control={control}
           name="annualGrowthRate"
@@ -43,34 +121,6 @@ export default function SalesRevenue({
               <FormLabel>Annual Sales Growth %</FormLabel>
               <FormControl>
                 <Input type="number" step="0.01" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={control}
-          name="avgSellingPriceYear1"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Avg. Selling Price (Year 1)</FormLabel>
-              <FormControl>
-                <Input type="number" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={control}
-          name="unitsSoldYear1"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Units Sold in Year 1</FormLabel>
-              <FormControl>
-                <Input type="number" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -89,41 +139,6 @@ export default function SalesRevenue({
               <FormMessage />
             </FormItem>
           )}
-        />
-
-        <FormField
-          control={control}
-          name="capacityUtilization"
-          render={({ field }) => {
-            // ensure we never map on undefined
-            const values: number[] = Array.isArray(field.value)
-              ? field.value
-              : [];
-            return (
-              <FormItem className="md:col-span-2">
-                <FormLabel>Capacity Utilization (% per Year)</FormLabel>
-                <FormControl>
-                  <div className="flex space-x-2">
-                    {values.map((val, idx) => (
-                      <Input
-                        key={idx}
-                        type="number"
-                        value={val}
-                        onChange={(e) => {
-                          // copy and update
-                          const newArr = [...values];
-                          newArr[idx] = Number(e.target.value);
-                          field.onChange(newArr);
-                        }}
-                        className="w-16"
-                      />
-                    ))}
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
         />
 
         <FormField

--- a/src/components/outputs/ComputationOfProductionReport.tsx
+++ b/src/components/outputs/ComputationOfProductionReport.tsx
@@ -9,7 +9,7 @@ type Props = {
 type RowFormat = 'number' | 'currency' | 'percent';
 
 // extended keys for formData
-type ExtendedKey = 'workingHours' | 'workingDays' | 'capacityUtilization';
+type ExtendedKey = 'workingHours' | 'workingDays';
 type Key = keyof Projection | ExtendedKey;
 
 export default function ComputationOfProductionReport({ formData, data }: Props) {
@@ -53,12 +53,6 @@ export default function ComputationOfProductionReport({ formData, data }: Props)
       showTotal: false,
     },
     {
-      label: 'Capacity Utilisation (%)',
-      key: 'capacityUtilization',
-      format: 'percent',
-      showTotal: false,
-    },
-    {
       label: 'Opening Stock (₹)',
       key: 'openingStock',
       format: 'currency',
@@ -67,18 +61,6 @@ export default function ComputationOfProductionReport({ formData, data }: Props)
     {
       label: 'Less: Closing Stock (₹)',
       key: 'closingStock',
-      format: 'currency',
-      showTotal: false,
-    },
-    {
-      label: 'Net Sale (₹)',
-      key: 'netSale',
-      format: 'currency',
-      showTotal: false,
-    },
-    {
-      label: 'Avg Sale Price (₹)',
-      key: 'avgSalePrice',
       format: 'currency',
       showTotal: false,
     },
@@ -115,11 +97,9 @@ export default function ComputationOfProductionReport({ formData, data }: Props)
         <tbody>
           {rows.map(({ label, key, format, showTotal }) => {
             // build per-year values for this row
-            const values = data.map((d, i) => {
+            const values = data.map((d) => {
               if (key === 'workingHours') return formData.workingHours;
               if (key === 'workingDays') return formData.workingDays;
-              if (key === 'capacityUtilization')
-                return formData.capacityUtilization[i] ?? 0;
               // otherwise pull from projection
               return (d[key as keyof Projection] ?? 0) as number;
             });

--- a/src/components/outputs/ProjectedProfitabilityReport.tsx
+++ b/src/components/outputs/ProjectedProfitabilityReport.tsx
@@ -22,9 +22,10 @@ export default function ProjectedProfitabilityReport({ data }: Props) {
   const electricity      = data.map((d) => d.electricityExpenses ?? 0);
   const labour           = data.map((d) => d.labourAndWages ?? 0);
   const overheads        = data.map((d) => d.otherOverheads ?? 0);
+  const outwardFreight   = data.map((d) => d.outwardFreight ?? 0);
   const openingStock     = data.map((d) => d.openingStock ?? 0);
   const closingStock     = data.map((d) => d.closingStock ?? 0);
-  const sellingExpenses  = data.map((d) => d.sellingExpenses ?? 0);
+  const inwardFreight    = data.map((d) => d.inwardFreight ?? 0);
   const adminExpenses    = data.map((d) => d.adminExpenses ?? 0);
   const depreciation     = data.map((d) => d.depreciation);
   const netProfit        = data.map((d) => d.netProfit);
@@ -33,7 +34,7 @@ export default function ProjectedProfitabilityReport({ data }: Props) {
   // Computed metrics
   const grossProfit      = revenue.map((r, i) => r - costOfSales[i]);
   const totalExpenses    = data.map((_, i) =>
-                          sellingExpenses[i] + adminExpenses[i] + depreciation[i]);
+                          inwardFreight[i] + adminExpenses[i] + depreciation[i]);
   const sum  = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
   const avg  = (arr: number[]) => (arr.length ? sum(arr) / arr.length : 0);
 
@@ -50,10 +51,11 @@ export default function ProjectedProfitabilityReport({ data }: Props) {
     { label: '   Electricity',            values: electricity },
     { label: '   Labour & Wages',         values: labour },
     { label: '   Other Overheads',        values: overheads },
+    { label: '   Outward Freight',        values: outwardFreight },
     { label: '   Add: Opening Stock',     values: openingStock },
     { label: '   Less: Closing Stock',    values: closingStock },
     { label: 'C) Gross Profit (A–B)',     values: grossProfit },
-    { label: 'D) Selling Expenses',       values: sellingExpenses },
+    { label: 'D) Inward Freight',         values: inwardFreight },
     { label: 'E) Administrative Expenses',values: adminExpenses },
     { label: 'F) Depreciation',           values: depreciation },
     { label: 'Total (D+E+F)',             values: totalExpenses },

--- a/src/pages/ReportBuilder.tsx
+++ b/src/pages/ReportBuilder.tsx
@@ -78,19 +78,15 @@ export default function ReportBuilder() {
       termLoanMoratorium: 0,
       wcLoanAmount: 0,
       wcLoanInterest: 0,
-      wcLoanTenure: 0,
       capitalSubsidyToggle: false,
       capitalSubsidyPercent: 0,
+      capitalSubsidyAmount: 0,
       loanProcessingFeePercent: 0,
 
       // Sales & Revenue
-      baseYearSales: 0,
+      products: [{ name: '', unitPrice: 0, quantity: 0, unit: '' }],
       annualGrowthRate: 10,
-      avgSellingPriceYear1: 0,
-      unitsSoldYear1: 0,
       priceInflation: 5,
-      // <— HERE: ensure this is always an array of length = projectionSpan
-      capacityUtilization: Array(defaultSpan).fill(0),
       workingDays: 300,
       workingHours: 8,
 
@@ -99,7 +95,8 @@ export default function ReportBuilder() {
       wagesLabourMonthly: 0,
       electricityMonthly: 0,
       otherOverheadsMonthly: 0,
-      sellingExpensesMonthly: 0,
+      outwardFreightMonthly: 0,
+      inwardFreightMonthly: 0,
       adminExpensesMonthly: 0,
 
       // Working Capital
@@ -111,6 +108,7 @@ export default function ReportBuilder() {
       // Depreciation
       method: 'WDV',
       assetLife: 5,
+      depreciationRate: 10,
 
       // Ledger / Cashflow
       openingBankBalance: 0,
@@ -118,8 +116,7 @@ export default function ReportBuilder() {
       openingDebtors: 0,
       openingCreditors: 0,
       monthlyDrawings: 0,
-      taxRate: 30,
-      gstRate: 18,
+      taxPercentage: 18,
       carryForwardEarnings: false,
     },
   });

--- a/src/types/formTypes.ts
+++ b/src/types/formTypes.ts
@@ -40,19 +40,23 @@ export interface FundingLoans {
   termLoanMoratorium: number;
   wcLoanAmount: number;        // WORKING CAPITAL LOAN on cover
   wcLoanInterest: number;
-  wcLoanTenure: number;
   capitalSubsidyToggle: boolean;
   capitalSubsidyPercent: number;
+  capitalSubsidyAmount: number;
   loanProcessingFeePercent: number;
 }
 
+export interface Product {
+  name: string;
+  unitPrice: number;
+  quantity: number;
+  unit: string;
+}
+
 export interface SalesRevenue {
-  baseYearSales: number;
+  products: Product[];
   annualGrowthRate: number;
-  avgSellingPriceYear1: number;
-  unitsSoldYear1: number;
   priceInflation: number;
-  capacityUtilization: number[];
   workingDays: number;
   workingHours: number;
 }
@@ -62,7 +66,8 @@ export interface ExpenseAssumptions {
   wagesLabourMonthly: number;
   electricityMonthly: number;
   otherOverheadsMonthly: number;
-  sellingExpensesMonthly: number;
+  outwardFreightMonthly: number;
+  inwardFreightMonthly: number;
   adminExpensesMonthly: number;
 }
 
@@ -76,6 +81,7 @@ export interface WorkingCapital {
 export interface Depreciation {
   method: 'WDV' | 'SLM';
   assetLife: number;
+  depreciationRate: number;
 }
 
 export interface LedgerCashflow {
@@ -84,8 +90,7 @@ export interface LedgerCashflow {
   openingDebtors?: number;
   openingCreditors?: number;
   monthlyDrawings: number;
-  taxRate: number;
-  gstRate: number;
+  taxPercentage: number;
   carryForwardEarnings: boolean;
 }
 
@@ -119,8 +124,6 @@ export interface Projection {
   closingCashBalance?: number;
   openingStock?: number;
   closingStock?: number;
-  netSale?: number;
-  avgSalePrice?: number;
   grossSale?: number;
   purchase?: number;
   electricityExpenses?: number;
@@ -130,7 +133,8 @@ export interface Projection {
   addition?: number;
   writtenDownValue?: number;
   rateOfDepreciation?: number;
-  sellingExpenses?: number;
+  outwardFreight?: number;
+  inwardFreight?: number;
   adminExpenses?: number;
 
 }


### PR DESCRIPTION
## Summary
- Auto-calculate owner capital, term loan, working capital loan and capital subsidy from project costs
- Model sales by multiple products and track freight expenses separately
- Add depreciation rate selection and replace tax inputs with India GST percentage dropdown

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689507498b7483338ed61a5eba922d33