### PR TITLE
Fix projection typings and PDF export color handling

### DIFF
--- a/src/components/PdfExporter.tsx
+++ b/src/components/PdfExporter.tsx
@@ -14,6 +14,20 @@ export async function exportToPdf() {
     scale: 2,
     useCORS: true,
     scrollY: -window.scrollY,
+    // html2canvas does not yet understand modern OKLCH colors used by
+    // Tailwind v4. Convert computed styles to RGB in the cloned document
+    // so the canvas render succeeds.
+    onclone: (clonedDoc) => {
+      const elements = clonedDoc.querySelectorAll('*');
+      elements.forEach((el) => {
+        const style = clonedDoc.defaultView?.getComputedStyle(el as Element);
+        if (style) {
+          (el as HTMLElement).style.color = style.color;
+          (el as HTMLElement).style.backgroundColor = style.backgroundColor;
+          (el as HTMLElement).style.borderColor = style.borderColor;
+        }
+      });
+    },
   });
 
   // Convert canvas to an image

--- a/src/types/formTypes.ts
+++ b/src/types/formTypes.ts
@@ -136,6 +136,12 @@ export interface Projection {
   outwardFreight?: number;
   inwardFreight?: number;
   adminExpenses?: number;
+  // newly added carry-forward balances
+  closingDebtors?: number;
+  subsidyOutstanding?: number;
+  termLoanOutstanding?: number;
+  cashCreditOutstanding?: number;
+  creditorsOutstanding?: number;
 
 }
 

--- a/src/utils/calculateProjections.ts
+++ b/src/utils/calculateProjections.ts
@@ -70,8 +70,8 @@ export default function calculateProjections(data: FormValues): Projection[] {
   let prevReserve = 0;
   let prevClosingCash = openingBankBalance;
   let wdvOpening = totalFixedAssets;
-  let cashCreditOutstanding = wcLoanAmount;
-  let subsidyOutstanding = capSubToggle
+  const cashCreditOutstanding = wcLoanAmount;
+  const subsidyOutstanding = capSubToggle
     ? (totalFixedAssets + preOpExpenses + workingCapitalRequirement) * capSubPct
     : 0;
 


### PR DESCRIPTION
## Summary
- extend `Projection` type with outstanding balance fields
- normalize OKLCH colors to RGB before html2canvas capture for PDF generation
- clean up calculation logic and build errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689516a8b8708333aa2992402d905de9