### PR TITLE
Implement reusable report storage and client retrieval

### DIFF
--- a/server/schema.sql
+++ b/server/schema.sql
@@ -7,14 +7,16 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS clients (
   id SERIAL PRIMARY KEY,
   user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
-  name TEXT NOT NULL
+  name TEXT NOT NULL,
+  UNIQUE (user_id, name)
 );
 
 CREATE TABLE IF NOT EXISTS projects (
   id SERIAL PRIMARY KEY,
   user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
   client_id INTEGER REFERENCES clients(id) ON DELETE CASCADE,
-  name TEXT NOT NULL
+  name TEXT NOT NULL,
+  UNIQUE (user_id, client_id, name)
 );
 
 CREATE TABLE IF NOT EXISTS reports (


### PR DESCRIPTION
## Summary
- enforce client and project uniqueness for each user
- add authenticated endpoints to list clients and reports
- reuse existing client and project records when saving reports

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm --prefix server test` *(fails: Missing script)*
- `npm --prefix server run build`


------
https://chatgpt.com/codex/tasks/task_e_6895462376e083338db05615fce77832