### PR TITLE
chore: prebundle router dom

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,7 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  optimizeDeps: {
+    include: ["react-router-dom"],
+  },
 })


### PR DESCRIPTION
## Summary
- ensure Vite prebundles `react-router-dom` so routing imports resolve properly

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68954b6cd9ac83339ffb1f608c9c8c81