### PR TITLE
Preserve return path after login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // src/App.tsx
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { SignedIn, UserButton } from '@clerk/clerk-react';
 import type { ReactNode } from 'react';
 import ReportBuilder from '@/pages/ReportBuilder';
@@ -8,8 +8,9 @@ import { useAuth } from '@clerk/clerk-react';
 
 function RequireAuth({ children }: { children: ReactNode }) {
   const { isSignedIn } = useAuth();
+  const location = useLocation();
   if (!isSignedIn) {
-    return <Navigate to="/login" />;
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />;
   }
   return <>{children}</>;
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,9 +1,12 @@
 import { SignIn } from '@clerk/clerk-react';
+import { useLocation } from 'react-router-dom';
 
 export default function Login() {
+  const location = useLocation();
+  const from = (location.state as { from?: string })?.from || '/';
   return (
     <div className="flex items-center justify-center min-h-screen bg-slate-50">
-      <SignIn path="/login" routing="path" afterSignInUrl="/" />
+      <SignIn path="/login" routing="path" afterSignInUrl={from} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- retain originally requested path when redirecting unauthenticated users
- forward stored path to Clerk SignIn so users return to form after login

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895570afd1483339bbb92efdb203c4f