### PR TITLE
fix: delay auth redirect until loaded

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,11 +7,17 @@ import Login from '@/pages/Login';
 import { useAuth } from '@clerk/clerk-react';
 
 function RequireAuth({ children }: { children: ReactNode }) {
-  const { isSignedIn } = useAuth();
+  const { isLoaded, isSignedIn } = useAuth();
   const location = useLocation();
+
+  if (!isLoaded) {
+    return null;
+  }
+
   if (!isSignedIn) {
     return <Navigate to="/login" state={{ from: location.pathname }} replace />;
   }
+
   return <>{children}</>;
 }
 


### PR DESCRIPTION
## Summary
- avoid redirecting signed-in users back to login by waiting for Clerk auth to load

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896891615708333ab7e7218ea778170