### PR TITLE
feat: add landing page and modern sidebar layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-route
 import type { ReactNode } from 'react';
 import ReportBuilder from '@/pages/ReportBuilder';
 import Login from '@/pages/Login';
+import Home from '@/pages/Home';
 import { useAuth } from '@clerk/clerk-react';
 import AppShell from '@/components/layout/AppShell';
 import { ToasterProvider } from '@/components/feedback/Toaster';
@@ -27,9 +28,10 @@ export default function App() {
     <BrowserRouter>
       <ToasterProvider>
         <Routes>
+          <Route index element={<Home />} />
           <Route path="/login/*" element={<Login />} />
           <Route
-            path="/*"
+            path="/report/*"
             element={
               <RequireAuth>
                 <AppShell>
@@ -40,6 +42,7 @@ export default function App() {
               </RequireAuth>
             }
           />
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </ToasterProvider>
     </BrowserRouter>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -11,37 +11,35 @@ interface AppShellProps {
 
 export default function AppShell({ children, toolbar }: AppShellProps) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      <header className="flex items-center justify-between border-b bg-card px-4 py-2">
-        <h1 className="text-xl font-semibold">Projection Builder</h1>
-        <div className="flex items-center gap-2">
-          {toolbar}
-          <ThemeToggle />
-          <SignedIn>
-            <UserButton afterSignOutUrl="/login" />
-          </SignedIn>
-        </div>
-      </header>
-      <div className="grid md:grid-cols-[200px,1fr] lg:grid-cols-[240px,1fr] min-h-[calc(100vh-3rem)]">
-        <nav className="hidden md:block border-r p-4">
+    <div className="flex min-h-screen bg-gradient-to-b from-white to-gray-100 text-foreground">
+      <nav className="flex w-56 flex-col justify-between bg-gradient-to-b from-black to-blue-900 p-4 text-white">
+        <div>
+          <h1 className="mb-6 text-lg font-semibold">Project Report</h1>
           <ul className="space-y-2 text-sm">
             <li>
               <NavLink
-                to="/"
+                to="/report"
                 className={({ isActive }) =>
                   cn(
-                    'block rounded-md px-3 py-2 hover:bg-muted',
-                    isActive && 'bg-muted'
+                    'block rounded-md px-3 py-2 hover:bg-blue-800',
+                    isActive && 'bg-blue-800'
                   )
                 }
               >
-                Report Builder
+                Project Report
               </NavLink>
             </li>
           </ul>
-        </nav>
-        <main className="p-4">{children}</main>
-      </div>
+        </div>
+        <div className="flex items-center justify-between gap-2 pt-4">
+          {toolbar}
+          <ThemeToggle />
+          <SignedIn>
+            <UserButton afterSignOutUrl="/" />
+          </SignedIn>
+        </div>
+      </nav>
+      <main className="flex-1 p-4">{children}</main>
     </div>
   );
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,20 @@
+import { SignInButton, useAuth } from '@clerk/clerk-react';
+import { Navigate } from 'react-router-dom';
+
+export default function Home() {
+  const { isSignedIn } = useAuth();
+
+  if (isSignedIn) {
+    return <Navigate to="/report" />;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white to-gray-100">
+      <SignInButton mode="modal">
+        <button className="rounded-md bg-blue-600 px-6 py-3 text-white shadow transition-colors hover:bg-blue-700">
+          Log In
+        </button>
+      </SignInButton>
+    </div>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,9 +3,9 @@ import { useLocation } from 'react-router-dom';
 
 export default function Login() {
   const location = useLocation();
-  const from = (location.state as { from?: string })?.from || '/';
+  const from = (location.state as { from?: string })?.from || '/report';
   return (
-    <div className="flex items-center justify-center min-h-screen bg-slate-50">
+    <div className="flex min-h-screen items-center justify-center bg-slate-50">
       <SignIn path="/login" routing="path" afterSignInUrl={from} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add dedicated landing page with login button
- restructure routing to separate home and authenticated report area
- replace header with dark gradient sidebar navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689696d2c5448333afb5a24e8f6b1f09