### PR TITLE
Revamp homepage layout and card styling

### DIFF
--- a/src/components/common/KPI.tsx
+++ b/src/components/common/KPI.tsx
@@ -12,7 +12,7 @@ export default function KPI({ label, value, delta }: KPIProps) {
   const Icon = delta === undefined ? null : delta >= 0 ? ArrowUpRight : ArrowDownRight;
   const positive = (delta ?? 0) >= 0;
   return (
-    <div className="rounded-xl border bg-card p-4 shadow-sm">
+    <div className="rounded-xl border bg-card p-4 shadow-lg backdrop-blur-sm">
       <p className="text-sm text-muted-foreground">{label}</p>
       <div className="flex items-center gap-1">
         <span className="text-2xl font-semibold font-mono">{value}</span>

--- a/src/components/common/ReportCard.tsx
+++ b/src/components/common/ReportCard.tsx
@@ -20,7 +20,7 @@ export default function ReportCard({
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ y: -4 }}
       transition={{ duration: 0.2 }}
-      className="rounded-2xl border bg-card text-card-foreground shadow-sm p-6"
+      className="rounded-2xl border bg-card p-6 text-card-foreground shadow-lg backdrop-blur-sm"
     >
       <div className="mb-4 flex items-start justify-between gap-4">
         <div>

--- a/src/components/form-sections/BusinessDetails.tsx
+++ b/src/components/form-sections/BusinessDetails.tsx
@@ -6,7 +6,7 @@ import type { FormValues } from "@/types/formTypes";
 
 export default function BusinessDetails({ control }: { control: Control<FormValues> }) {
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">1️⃣ Business Details</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <Field control={control} name="businessName" label="Business Name">

--- a/src/components/form-sections/CostOfProject.tsx
+++ b/src/components/form-sections/CostOfProject.tsx
@@ -18,7 +18,7 @@ export default function CostOfProject({ control }: { control: Control<FormValues
   const { fields, append, remove } = useFieldArray({ control, name: "costItems" });
 
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">3️⃣ Cost of Project</h2>
       <table className="w-full text-sm border-collapse">
         <thead>

--- a/src/components/form-sections/ExpenseAssumptions.tsx
+++ b/src/components/form-sections/ExpenseAssumptions.tsx
@@ -6,7 +6,7 @@ import type { FormValues } from "@/types/formTypes";
 
 export default function ExpenseAssumptions({ control }: { control: Control<FormValues> }) {
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">6️⃣ Expense Assumptions</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField

--- a/src/components/form-sections/FundingLoans.tsx
+++ b/src/components/form-sections/FundingLoans.tsx
@@ -46,7 +46,7 @@ export default function FundingLoans({
   setValue("wcLoanAmount", wcRequirement);
   setValue("capitalSubsidyAmount", subsidyAmount);
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">4️⃣ Funding / Loans</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField

--- a/src/components/form-sections/LedgerCashflow.tsx
+++ b/src/components/form-sections/LedgerCashflow.tsx
@@ -8,7 +8,7 @@ import type { FormValues } from "@/types/formTypes";
 
 export default function LedgerCashflow({ control }: { control: Control<FormValues> }) {
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">9️⃣ Ledger / Cashflow</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField

--- a/src/components/form-sections/ProjectTimeline.tsx
+++ b/src/components/form-sections/ProjectTimeline.tsx
@@ -6,7 +6,7 @@ import type { FormValues } from "@/types/formTypes";
 
 export default function ProjectTimeline({ control }: { control: Control<FormValues> }) {
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">2️⃣ Project Timeline</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField

--- a/src/components/form-sections/SalesRevenue.tsx
+++ b/src/components/form-sections/SalesRevenue.tsx
@@ -18,7 +18,7 @@ export default function SalesRevenue({
 }) {
   const { fields, append, remove } = useFieldArray({ control, name: "products" });
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">
         5️⃣ Sales & Revenue Assumptions
       </h2>

--- a/src/components/form-sections/WorkingCapital.tsx
+++ b/src/components/form-sections/WorkingCapital.tsx
@@ -6,7 +6,7 @@ import type { FormValues } from "@/types/formTypes";
 
 export default function WorkingCapital({ control }: { control: Control<FormValues> }) {
   return (
-    <section className="border border-slate-200 rounded-md p-6 shadow-sm">
+    <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">7️⃣ Working Capital</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-lg backdrop-blur-sm",
         className
       )}
       {...props}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,12 +9,20 @@ export default function Home() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white to-gray-100">
-      <SignInButton mode="modal">
-        <button className="rounded-md bg-blue-600 px-6 py-3 text-white shadow transition-colors hover:bg-blue-700">
-          Log In
-        </button>
-      </SignInButton>
+    <div className="flex min-h-screen flex-col md:flex-row bg-gradient-to-br from-gray-900 via-gray-800 to-black text-white">
+      <div className="flex w-full flex-1 items-center justify-center bg-gray-800/60 p-8 backdrop-blur-sm">
+        <SignInButton mode="modal">
+          <button className="rounded-md bg-blue-600 px-6 py-3 text-white shadow-lg transition-colors hover:bg-blue-700">
+            Log In
+          </button>
+        </SignInButton>
+      </div>
+      <div className="flex w-full flex-1 flex-col items-center justify-center p-8 text-center">
+        <h1 className="mb-4 text-4xl font-bold">Kazezeus Finance</h1>
+        <p className="max-w-md text-lg text-gray-300">
+          Empowering your financial journey with smart solutions.
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Redesign homepage with company branding, dark gradient background, and split layout for login and marketing copy
- Add depth and translucent backgrounds to form sections and shared card components for a more polished look

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68969a81c964833387f6c227387f78de