### PR TITLE
Add backend report saving and client management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,9 @@
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import type { ReactNode } from 'react';
 import ReportBuilder from '@/pages/ReportBuilder';
+import Clients from '@/pages/Clients';
+import SavedReports from '@/pages/SavedReports';
+import SavedReport from '@/pages/SavedReport';
 import Login from '@/pages/Login';
 import Home from '@/pages/Home';
 import { useAuth } from '@clerk/clerk-react';
@@ -31,12 +34,16 @@ export default function App() {
           <Route index element={<Home />} />
           <Route path="/login/*" element={<Login />} />
           <Route
-            path="/report/*"
+            path="/app/*"
             element={
               <RequireAuth>
                 <AppShell>
                   <Routes>
-                    <Route index element={<ReportBuilder />} />
+                    <Route index element={<Navigate to="report" replace />} />
+                    <Route path="report" element={<ReportBuilder />} />
+                    <Route path="clients" element={<Clients />} />
+                    <Route path="saved-reports" element={<SavedReports />} />
+                    <Route path="saved-reports/:id" element={<SavedReport />} />
                   </Routes>
                 </AppShell>
               </RequireAuth>

--- a/src/components/ReportOutput.tsx
+++ b/src/components/ReportOutput.tsx
@@ -1,0 +1,101 @@
+import SectionHeader from '@/components/common/SectionHeader';
+import ReportCard from '@/components/common/ReportCard';
+import KPI from '@/components/common/KPI';
+import CoverReport from '@/components/outputs/CoverReport';
+import CostOfProjectReport from '@/components/outputs/CostOfProjectReport';
+import MeansOfFinanceReport from '@/components/outputs/MeansOfFinanceReport';
+import CapitalSubsidyReport from '@/components/outputs/CapitalSubsidyReport';
+import ProjectedCashFlowReport from '@/components/outputs/ProjectedCashFlowReport';
+import KeyRatiosReport from '@/components/outputs/KeyRatiosReport';
+import ProjectedBalanceSheetReport from '@/components/outputs/ProjectedBalanceSheetReport';
+import ProjectedProfitabilityReport from '@/components/outputs/ProjectedProfitabilityReport';
+import ComputationOfProductionReport from '@/components/outputs/ComputationOfProductionReport';
+import ComputationOfWorkingCapitalRequirementReport from '@/components/outputs/ComputationOfWorkingCapitalRequirementReport';
+import ComputationOfDepreciationReport from '@/components/outputs/ComputationOfDepreciationReport';
+import RepaymentScheduleReport from '@/components/outputs/RepaymentScheduleReport';
+import DSCRReport from '@/components/outputs/DSCRReport';
+import { exportToPdf } from '@/components/PdfExporter';
+import type { FormValues, Projection } from '@/types/formTypes';
+import { formatCurrency, formatNumber } from '@/utils/format';
+
+interface ReportOutputProps {
+  formData: FormValues;
+  results: Projection[];
+}
+
+export default function ReportOutput({ formData, results }: ReportOutputProps) {
+  const first = results[0];
+  const kpis = [
+    { label: 'Revenue', value: formatCurrency(first.revenue) },
+    { label: 'Net Profit', value: formatCurrency(first.netProfit) },
+    { label: 'DSCR', value: formatNumber(first.dscr) },
+    { label: 'Current Ratio', value: formatNumber(first.currentRatio) },
+  ];
+
+  return (
+    <div id="report" className="space-y-6">
+      <SectionHeader title="Report Preview" />
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {kpis.map((k) => (
+          <KPI key={k.label} label={k.label} value={k.value} />
+        ))}
+      </div>
+
+      <ReportCard title="Cover" description="Basic project details">
+        <CoverReport formData={formData} />
+      </ReportCard>
+
+      <ReportCard title="Cost of Project" description="Breakdown of project costs">
+        <CostOfProjectReport formData={formData} />
+      </ReportCard>
+
+      <ReportCard title="Means of Finance" description="Funding structure">
+        <MeansOfFinanceReport formData={formData} />
+        <CapitalSubsidyReport formData={formData} />
+      </ReportCard>
+
+      <ReportCard title="Projected Cash Flow" description="Yearly cash flow projections">
+        <ProjectedCashFlowReport formData={formData} data={results} />
+      </ReportCard>
+
+      <ReportCard title="Key Ratios" description="Financial ratios summary">
+        <KeyRatiosReport data={results} />
+      </ReportCard>
+
+      <ReportCard title="Balance Sheet" description="Projected balance sheet">
+        <ProjectedBalanceSheetReport formData={formData} data={results} />
+      </ReportCard>
+
+      <ReportCard title="Profitability" description="Projected profit and loss">
+        <ProjectedProfitabilityReport data={results} />
+      </ReportCard>
+
+      <ReportCard title="Production" description="Computation of production">
+        <ComputationOfProductionReport formData={formData} data={results} />
+      </ReportCard>
+
+      <ReportCard title="Working Capital Requirement" description="Computation of working capital requirement">
+        <ComputationOfWorkingCapitalRequirementReport formData={formData} data={results} />
+      </ReportCard>
+
+      <ReportCard title="Depreciation" description="Computation of depreciation">
+        <ComputationOfDepreciationReport data={results} />
+      </ReportCard>
+
+      <ReportCard title="Repayment Schedule" description="Loan repayment schedule">
+        <RepaymentScheduleReport formData={formData} data={results} />
+      </ReportCard>
+
+      <ReportCard title="DSCR" description="Debt service coverage ratio">
+        <DSCRReport formData={formData} data={results} />
+      </ReportCard>
+
+      <button
+        onClick={exportToPdf}
+        className="mt-6 inline-block border border-blue-600 text-blue-600 px-4 py-2 rounded hover:bg-blue-600 hover:text-white"
+      >
+        Download PDF
+      </button>
+    </div>
+  );
+}

--- a/src/components/form-sections/BusinessDetails.tsx
+++ b/src/components/form-sections/BusinessDetails.tsx
@@ -4,12 +4,42 @@ import { Field } from "@/components/forms/Field";
 import type { Control } from "react-hook-form";
 import type { FormValues } from "@/types/formTypes";
 
-export default function BusinessDetails({ control }: { control: Control<FormValues> }) {
+interface BusinessDetailsProps {
+  control: Control<FormValues>;
+  clients: { id: number; name: string }[];
+}
+
+export default function BusinessDetails({ control, clients }: BusinessDetailsProps) {
   return (
     <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
       <h2 className="text-lg font-semibold mb-4 text-slate-700">1️⃣ Business Details</h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Field control={control} name="businessName" label="Business Name">
+        <FormField
+          control={control}
+          name="clientName"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Client</FormLabel>
+              <FormControl>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select client" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {clients.map((c) => (
+                      <SelectItem key={c.id} value={c.name}>
+                        {c.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <Field control={control} name="businessName" label="Project Name">
           {(field) => <Input {...field} />}
         </Field>
 
@@ -36,10 +66,6 @@ export default function BusinessDetails({ control }: { control: Control<FormValu
             </FormItem>
           )}
         />
-
-        <Field control={control} name="ownerName" label="Owner Name">
-          {(field) => <Input {...field} />}
-        </Field>
 
         <FormField
           control={control}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -18,7 +18,7 @@ export default function AppShell({ children, toolbar }: AppShellProps) {
           <ul className="space-y-2 text-sm">
             <li>
               <NavLink
-                to="/report"
+                to="/app/report"
                 className={({ isActive }) =>
                   cn(
                     'block rounded-md px-3 py-2 hover:bg-blue-800',
@@ -29,9 +29,35 @@ export default function AppShell({ children, toolbar }: AppShellProps) {
                 Project Report
               </NavLink>
             </li>
+            <li>
+              <NavLink
+                to="/app/clients"
+                className={({ isActive }) =>
+                  cn(
+                    'block rounded-md px-3 py-2 hover:bg-blue-800',
+                    isActive && 'bg-blue-800'
+                  )
+                }
+              >
+                Clients
+              </NavLink>
+            </li>
+            <li>
+              <NavLink
+                to="/app/saved-reports"
+                className={({ isActive }) =>
+                  cn(
+                    'block rounded-md px-3 py-2 hover:bg-blue-800',
+                    isActive && 'bg-blue-800'
+                  )
+                }
+              >
+                Saved Reports
+              </NavLink>
+            </li>
           </ul>
         </div>
-        <div className="flex items-center justify-between gap-2 pt-4">
+        <div className="flex items-center justify-between gap-2 border-t border-white/20 pt-4 mt-4">
           {toolbar}
           <ThemeToggle />
           <SignedIn>

--- a/src/components/outputs/CoverReport.tsx
+++ b/src/components/outputs/CoverReport.tsx
@@ -19,7 +19,7 @@ export default function CoverReport({ formData }: Props) {
           </tr>
           <tr>
             <td className="border border-gray-300 p-2 font-semibold">Name of Proprietor</td>
-            <td className="border border-gray-300 p-2">{formData.ownerName}</td>
+            <td className="border border-gray-300 p-2">{formData.clientName}</td>
           </tr>
           <tr>
             <td className="border border-gray-300 p-2 font-semibold">Category</td>

--- a/src/pages/Clients.tsx
+++ b/src/pages/Clients.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useAuth, useUser } from '@clerk/clerk-react';
+
+interface Client {
+  id: number;
+  name: string;
+}
+
+export default function Clients() {
+  const { getToken } = useAuth();
+  const { user } = useUser();
+  const [clients, setClients] = useState<Client[]>([]);
+  const [name, setName] = useState('');
+
+  const fetchClients = useCallback(async () => {
+    try {
+      const token = await getToken();
+      const res = await fetch('/api/clients', {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      setClients(data.clients);
+    } catch (err) {
+      console.error('Failed to load clients', err);
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    fetchClients();
+  }, [fetchClients]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const token = await getToken();
+      await fetch('/api/clients', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          name,
+          userEmail: user?.primaryEmailAddress?.emailAddress,
+        }),
+      });
+      setName('');
+      fetchClients();
+    } catch (err) {
+      console.error('Failed to save client', err);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto py-8 px-4">
+      <form onSubmit={handleSubmit} className="mb-4 flex gap-2">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="flex-1 rounded border px-3 py-2"
+          placeholder="Client name"
+        />
+        <button type="submit" className="rounded bg-blue-600 px-4 py-2 text-white">
+          Add
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {clients.map((c) => (
+          <li key={c.id} className="rounded border p-2">
+            {c.name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   const { isSignedIn } = useAuth();
 
   if (isSignedIn) {
-    return <Navigate to="/report" />;
+    return <Navigate to="/app/report" />;
   }
 
   return (

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 
 export default function Login() {
   const location = useLocation();
-  const from = (location.state as { from?: string })?.from || '/report';
+  const from = (location.state as { from?: string })?.from || '/app/report';
   return (
     <div className="flex min-h-screen items-center justify-center bg-slate-50">
       <SignIn path="/login" routing="path" afterSignInUrl={from} />

--- a/src/pages/SavedReport.tsx
+++ b/src/pages/SavedReport.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useAuth } from '@clerk/clerk-react';
+import type { FormValues, Projection } from '@/types/formTypes';
+import calculateProjections from '@/utils/calculateProjections';
+import ReportOutput from '@/components/ReportOutput';
+
+export default function SavedReport() {
+  const { id } = useParams();
+  const { getToken } = useAuth();
+  const [formData, setFormData] = useState<FormValues | null>(null);
+  const [results, setResults] = useState<Projection[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const token = await getToken();
+        const res = await fetch(`/api/reports/${id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await res.json();
+        const reportData: FormValues = data.report.data;
+        setFormData(reportData);
+        const raw = calculateProjections(reportData);
+        const projections = raw.map((p, i) => ({
+          ...p,
+          year: Number.isFinite(p.year) ? p.year : i + 1,
+        }));
+        setResults(projections);
+      } catch (err) {
+        console.error('Failed to load report', err);
+      }
+    })();
+  }, [id, getToken]);
+
+  if (!formData || results.length === 0) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto py-8 px-4">
+      <Link to="/app/saved-reports" className="mb-6 inline-block rounded bg-gray-200 px-4 py-2">
+        Back to list
+      </Link>
+      <ReportOutput formData={formData} results={results} />
+    </div>
+  );
+}

--- a/src/pages/SavedReports.tsx
+++ b/src/pages/SavedReports.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+import { Link } from 'react-router-dom';
+
+interface Report {
+  id: number;
+  client_name: string;
+  project_name: string;
+}
+
+export default function SavedReports() {
+  const { getToken } = useAuth();
+  const [reports, setReports] = useState<Report[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const token = await getToken();
+        const res = await fetch('/api/reports', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const data = await res.json();
+        setReports(data.reports);
+      } catch (err) {
+        console.error('Failed to load reports', err);
+      }
+    })();
+  }, [getToken]);
+
+  return (
+    <div className="max-w-3xl mx-auto py-8 px-4">
+      <h2 className="mb-4 text-xl font-semibold">Saved Reports</h2>
+      <ul className="space-y-2">
+        {reports.map((r) => (
+          <li key={r.id} className="rounded border p-2">
+            <Link
+              to={`/app/saved-reports/${r.id}`}
+              className="text-blue-600 hover:underline"
+            >
+              {r.project_name} - {r.client_name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/types/formTypes.ts
+++ b/src/types/formTypes.ts
@@ -5,9 +5,9 @@
 export interface BusinessDetails {
   businessName: string;
   constitutionType: string;
-  ownerName: string;
+  clientName: string;
   mobile: string;             // MOBILE on cover
-  email: string;              
+  email: string;
   projectType: string;        // TYPE OF PROJECT on cover
   address: string;
   industryType: string;        // CATEGORY on cover


### PR DESCRIPTION
## Summary
- save new clients separately through `/api/clients`
- add Save Report button, client selector, and pages for clients and saved reports
- expand navigation with links for clients and saved reports

## Testing
- `npm run lint`
- `npm run build`
- `npm run server:build`


------
https://chatgpt.com/codex/tasks/task_e_6896a6e6b0448333abb6405dbfea8c38