### PR TITLE
Fix frontend proxy for API requests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,4 +14,9 @@ export default defineConfig({
   optimizeDeps: {
     include: ["react-router-dom"],
   },
+  server: {
+    proxy: {
+      "/api": "http://localhost:3000",
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- proxy `/api` requests in Vite dev server to backend on port 3000

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896ab2ccc908333acfc60b71cda7fc8