### PR TITLE
feat: refine cost of project inputs with asset type and rupee formatting

### DIFF
--- a/src/components/form-sections/CostOfProject.tsx
+++ b/src/components/form-sections/CostOfProject.tsx
@@ -1,6 +1,17 @@
 import { Input } from "@/components/ui/input";
-import { FormField, FormItem, FormControl, FormMessage } from "@/components/ui/form";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  FormField,
+  FormItem,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import type { Control } from "react-hook-form";
 import { useFieldArray } from "react-hook-form";
@@ -16,6 +27,8 @@ const typeOptions = [
 
 export default function CostOfProject({ control }: { control: Control<FormValues> }) {
   const { fields, append, remove } = useFieldArray({ control, name: "costItems" });
+  const fmt = (n: number) =>
+    '₹' + Math.round(n).toLocaleString('en-IN', { maximumFractionDigits: 0 });
 
   return (
     <section className="rounded-lg border border-slate-300 bg-white/80 p-6 shadow-lg backdrop-blur-sm dark:border-slate-700 dark:bg-slate-900/60">
@@ -23,96 +36,144 @@ export default function CostOfProject({ control }: { control: Control<FormValues
       <table className="w-full text-sm border-collapse">
         <thead>
           <tr className="bg-slate-100">
-            <th className="p-2 text-left border">Type</th>
+            <th className="p-2 text-left border">Particulars</th>
+            <th className="p-2 text-right border">Amount</th>
             <th className="p-2 text-right border">Margin %</th>
             <th className="p-2 text-right border">Dep %</th>
-            <th className="p-2 text-right border">Amount</th>
+            <th className="p-2 text-left border">Asset Type</th>
+            <th className="p-2 text-right border">Margin (₹)</th>
+            <th className="p-2 text-right border">Finance (₹)</th>
             <th className="p-2 border"></th>
           </tr>
         </thead>
         <tbody>
-          {fields.map((field, index) => (
-            <tr key={field.id}>
-              <td className="p-2 border">
-                <FormField
-                  control={control}
-                  name={`costItems.${index}.type`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Select onValueChange={field.onChange} defaultValue={field.value}>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select type" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {typeOptions.map((opt) => (
-                              <SelectItem key={opt} value={opt}>
-                                {opt}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </td>
-              <td className="p-2 border">
-                <FormField
-                  control={control}
-                  name={`costItems.${index}.marginPercent`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Input type="number" step="0.01" className="text-right" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </td>
-              <td className="p-2 border">
-                <FormField
-                  control={control}
-                  name={`costItems.${index}.depreciationRate`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Input type="number" step="0.01" className="text-right" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </td>
-              <td className="p-2 border">
-                <FormField
-                  control={control}
-                  name={`costItems.${index}.amount`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <Input type="number" className="text-right" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </td>
-              <td className="p-2 border text-center">
-                <Button type="button" variant="destructive" size="sm" onClick={() => remove(index)}>
-                  Remove
-                </Button>
-              </td>
-            </tr>
-          ))}
+          {fields.map((field, index) => {
+            const amount = Number(field.amount) || 0;
+            const marginPct = Number(field.marginPercent) || 0;
+            const marginAmt = (amount * marginPct) / 100;
+            const financeAmt = amount - marginAmt;
+            return (
+              <tr key={field.id}>
+                <td className="p-2 border">
+                  <FormField
+                    control={control}
+                    name={`costItems.${index}.type`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Select onValueChange={field.onChange} defaultValue={field.value}>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select type" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {typeOptions.map((opt) => (
+                                <SelectItem key={opt} value={opt}>
+                                  {opt}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </td>
+                <td className="p-2 border">
+                  <FormField
+                    control={control}
+                    name={`costItems.${index}.amount`}
+                    rules={{ min: 0 }}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input type="number" className="text-right" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </td>
+                <td className="p-2 border">
+                  <FormField
+                    control={control}
+                    name={`costItems.${index}.marginPercent`}
+                    rules={{ min: 0, max: 100 }}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input type="number" step="0.01" className="text-right" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </td>
+                <td className="p-2 border">
+                  <FormField
+                    control={control}
+                    name={`costItems.${index}.depreciationRate`}
+                    rules={{ min: 0, max: 100 }}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input type="number" step="0.01" className="text-right" {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </td>
+                <td className="p-2 border">
+                  <FormField
+                    control={control}
+                    name={`costItems.${index}.assetType`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Select onValueChange={field.onChange} defaultValue={field.value}>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="Fixed">Fixed</SelectItem>
+                              <SelectItem value="Current">Current</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </td>
+                <td className="p-2 border text-right">
+                  {fmt(marginAmt)}
+                </td>
+                <td className="p-2 border text-right">
+                  {fmt(financeAmt)}
+                </td>
+                <td className="p-2 border text-center">
+                  <Button type="button" variant="destructive" size="sm" onClick={() => remove(index)}>
+                    Remove
+                  </Button>
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       <Button
         type="button"
         className="mt-4"
-        onClick={() => append({ type: "", marginPercent: 0, depreciationRate: 0, amount: 0 })}
+        onClick={() =>
+          append({
+            type: '',
+            marginPercent: 0,
+            depreciationRate: 0,
+            amount: 0,
+            assetType: 'Fixed',
+          })
+        }
       >
         Add Row
       </Button>

--- a/src/pages/ReportBuilder.tsx
+++ b/src/pages/ReportBuilder.tsx
@@ -66,11 +66,41 @@ export default function ReportBuilder() {
 
       // Cost of Project
       costItems: [
-        { type: 'Machinery & Equipment', marginPercent: 0, amount: 0, depreciationRate: 0 },
-        { type: 'Furniture / Fixtures', marginPercent: 0, amount: 0, depreciationRate: 0 },
-        { type: 'Other Fixed Assets', marginPercent: 0, amount: 0, depreciationRate: 0 },
-        { type: 'Pre-operating Expenses', marginPercent: 0, amount: 0, depreciationRate: 0 },
-        { type: 'Working Capital Requirement', marginPercent: 15, amount: 0, depreciationRate: 0 },
+        {
+          type: 'Machinery & Equipment',
+          marginPercent: 0,
+          amount: 0,
+          depreciationRate: 0,
+          assetType: 'Fixed',
+        },
+        {
+          type: 'Furniture / Fixtures',
+          marginPercent: 0,
+          amount: 0,
+          depreciationRate: 0,
+          assetType: 'Fixed',
+        },
+        {
+          type: 'Other Fixed Assets',
+          marginPercent: 0,
+          amount: 0,
+          depreciationRate: 0,
+          assetType: 'Fixed',
+        },
+        {
+          type: 'Pre-operating Expenses',
+          marginPercent: 0,
+          amount: 0,
+          depreciationRate: 0,
+          assetType: 'Fixed',
+        },
+        {
+          type: 'Working Capital Requirement',
+          marginPercent: 15,
+          amount: 0,
+          depreciationRate: 0,
+          assetType: 'Current',
+        },
       ],
 
       // Funding / Loans

--- a/src/types/formTypes.ts
+++ b/src/types/formTypes.ts
@@ -31,6 +31,7 @@ export interface CostItem {
   marginPercent: number;
   amount: number;
   depreciationRate?: number;
+  assetType: 'Fixed' | 'Current';
 }
 
 export interface FundingLoans {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,12 +1,12 @@
 export const formatNumber = (value: number): string =>
-  new Intl.NumberFormat('en-IN', { maximumFractionDigits: 2 }).format(value);
+  new Intl.NumberFormat('en-IN', { maximumFractionDigits: 0 }).format(Math.round(value));
 
 export const formatCurrency = (value: number): string =>
   new Intl.NumberFormat('en-IN', {
     style: 'currency',
     currency: 'INR',
-    maximumFractionDigits: 2,
-  }).format(value);
+    maximumFractionDigits: 0,
+  }).format(Math.round(value));
 
 export const formatPercent = (value: number): string =>
   `${value.toFixed(2)}%`;


### PR DESCRIPTION
## Summary
- add asset type and derived margin/finance columns in Cost of Project form
- support asset type in data model and default cost items
- round currency formatting to whole rupees

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897bdec72ac8333b67c6871682a3ff0